### PR TITLE
Make namenode listen to all interfaces.

### DIFF
--- a/hdfs-site.xml
+++ b/hdfs-site.xml
@@ -3,4 +3,13 @@
         <name>dfs.replication</name>
         <value>1</value>
     </property>
+
+    <property>
+        <name>dfs.namenode.rpc-bind-host</name>
+        <value>0.0.0.0</value>
+    </property>
+    <property>
+        <name>dfs.namenode.servicerpc-bind-host</name>
+        <value>0.0.0.0</value>
+    </property>
 </configuration>


### PR DESCRIPTION
Change dfs.namenode.rpc-bind-host and dfs.namenode.servicerpc-bind-host to
"0.0.0.0" so that namenode RPC (client and HDFS services)
will be listening to all interfaces.
